### PR TITLE
Make client more resilient with better response parser, resource tracking

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -395,7 +395,7 @@ javax.net.debug=ssl:handshake:verbose
     <profile>
       <id>ci</id>
 
-      <properties>
+<!--       <properties>
         <dockerNetworkMode>custom</dockerNetworkMode>
         <dockerNetwork>ci-network</dockerNetwork>
 
@@ -424,7 +424,7 @@ javax.net.debug=ssl:handshake:verbose
           </plugin>
         </plugins>
       </build>
-    </profile>
+ -->    </profile>
     <profile>
       <id>local-its</id>
       <build>

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,8 @@
   <properties>
     <projectOwner>Red Hat, Inc.</projectOwner>
     <javaVersion>1.7</javaVersion>
-    <httpcVersion>4.4</httpcVersion>
+    <httpcoreVersion>4.4.6</httpcoreVersion>
+    <httpclientVersion>4.5.3</httpclientVersion>
     <dockerWaitFor>Setting LogLevel for all modules to trace6</dockerWaitFor>
 
     <dockerImage>docker.io/commonjava/ssl-dojo:1.1</dockerImage>
@@ -81,12 +82,12 @@
       <dependency>
         <groupId>org.apache.httpcomponents</groupId>
         <artifactId>httpclient</artifactId>
-        <version>${httpcVersion}</version>
+        <version>${httpclientVersion}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.httpcomponents</groupId>
         <artifactId>httpcore</artifactId>
-        <version>${httpcVersion}</version>
+        <version>${httpcoreVersion}</version>
       </dependency>
       <dependency>
         <groupId>org.bouncycastle</groupId>
@@ -106,7 +107,7 @@
       <dependency>
         <groupId>org.commonjava.util</groupId>
         <artifactId>http-testserver</artifactId>
-        <version>1.1</version>
+        <version>1.3</version>
         <scope>test</scope>
       </dependency>
     </dependencies>

--- a/src/main/java/org/commonjava/util/jhttpc/HttpFactory.java
+++ b/src/main/java/org/commonjava/util/jhttpc/HttpFactory.java
@@ -127,6 +127,7 @@ public class HttpFactory
             }
 
             ConnectionManagerTracker managerWrapper = connectionCache.getTrackerFor( connConfig );
+            logger.debug( "Using connection manager tracker: {}", managerWrapper );
             builder.setConnectionManager( managerWrapper.acquire() );
 
             if ( location.getProxyHost() != null )

--- a/src/main/java/org/commonjava/util/jhttpc/INTERNAL/conn/SiteConnectionConfig.java
+++ b/src/main/java/org/commonjava/util/jhttpc/INTERNAL/conn/SiteConnectionConfig.java
@@ -94,4 +94,9 @@ public class SiteConnectionConfig
     {
         return config.getMaxConnections();
     }
+
+    public String getId()
+    {
+        return config.getId();
+    }
 }

--- a/src/main/java/org/commonjava/util/jhttpc/INTERNAL/conn/TrackedHttpClient.java
+++ b/src/main/java/org/commonjava/util/jhttpc/INTERNAL/conn/TrackedHttpClient.java
@@ -26,6 +26,8 @@ import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.params.HttpParams;
 import org.apache.http.protocol.HttpContext;
 import org.commonjava.util.jhttpc.INTERNAL.util.HttpUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.lang.ref.WeakReference;
@@ -56,6 +58,8 @@ public class TrackedHttpClient
     protected CloseableHttpResponse doExecute( HttpHost target, HttpRequest request, HttpContext context )
             throws IOException, ClientProtocolException
     {
+        Logger logger = LoggerFactory.getLogger( getClass() );
+        logger.info( "Tracking request/response" );
         requests.add( new WeakReference<HttpRequest>( request ) );
 
         CloseableHttpResponse response = delegate.execute( target, request, context );
@@ -64,62 +68,64 @@ public class TrackedHttpClient
         return response;
     }
 
-    @Override
-    public CloseableHttpResponse execute( HttpHost target, HttpRequest request, HttpContext context )
-            throws IOException, ClientProtocolException
-    {
-        return delegate.execute( target, request, context );
-    }
-
-    @Override
-    public CloseableHttpResponse execute( HttpUriRequest request, HttpContext context )
-            throws IOException, ClientProtocolException
-    {
-        return delegate.execute( request, context );
-    }
-
-    @Override
-    public CloseableHttpResponse execute( HttpUriRequest request )
-            throws IOException, ClientProtocolException
-    {
-        return delegate.execute( request );
-    }
-
-    @Override
-    public CloseableHttpResponse execute( HttpHost target, HttpRequest request )
-            throws IOException, ClientProtocolException
-    {
-        return delegate.execute( target, request );
-    }
-
-    @Override
-    public <T> T execute( HttpUriRequest request, ResponseHandler<? extends T> responseHandler )
-            throws IOException, ClientProtocolException
-    {
-        return delegate.execute( request, responseHandler );
-    }
-
-    @Override
-    public <T> T execute( HttpUriRequest request, ResponseHandler<? extends T> responseHandler, HttpContext context )
-            throws IOException, ClientProtocolException
-    {
-        return delegate.execute( request, responseHandler, context );
-    }
-
-    @Override
-    public <T> T execute( HttpHost target, HttpRequest request, ResponseHandler<? extends T> responseHandler )
-            throws IOException, ClientProtocolException
-    {
-        return delegate.execute( target, request, responseHandler );
-    }
-
-    @Override
-    public <T> T execute( HttpHost target, HttpRequest request, ResponseHandler<? extends T> responseHandler,
-                          HttpContext context )
-            throws IOException, ClientProtocolException
-    {
-        return delegate.execute( target, request, responseHandler, context );
-    }
+//    @Override
+//    public CloseableHttpResponse execute( final HttpHost target, final HttpRequest request, final HttpContext context )
+//            throws IOException, ClientProtocolException
+//    {
+//        return delegate.execute( target, request, context );
+//    }
+//
+//    @Override
+//    public CloseableHttpResponse execute( final HttpUriRequest request, final HttpContext context )
+//            throws IOException, ClientProtocolException
+//    {
+//        return delegate.execute( request, context );
+//    }
+//
+//    @Override
+//    public CloseableHttpResponse execute( final HttpUriRequest request )
+//            throws IOException, ClientProtocolException
+//    {
+//        return delegate.execute( request );
+//    }
+//
+//    @Override
+//    public CloseableHttpResponse execute( final HttpHost target, final HttpRequest request )
+//            throws IOException, ClientProtocolException
+//    {
+//        return delegate.execute( target, request );
+//    }
+//
+//    @Override
+//    public <T> T execute( final HttpUriRequest request, final ResponseHandler<? extends T> responseHandler )
+//            throws IOException, ClientProtocolException
+//    {
+//        return delegate.execute( request, responseHandler );
+//    }
+//
+//    @Override
+//    public <T> T execute( final HttpUriRequest request, final ResponseHandler<? extends T> responseHandler,
+//                          final HttpContext context )
+//            throws IOException, ClientProtocolException
+//    {
+//        return delegate.execute( request, responseHandler, context );
+//    }
+//
+//    @Override
+//    public <T> T execute( final HttpHost target, final HttpRequest request,
+//                          final ResponseHandler<? extends T> responseHandler )
+//            throws IOException, ClientProtocolException
+//    {
+//        return delegate.execute( target, request, responseHandler );
+//    }
+//
+//    @Override
+//    public <T> T execute( final HttpHost target, final HttpRequest request,
+//                          final ResponseHandler<? extends T> responseHandler, final HttpContext context )
+//            throws IOException, ClientProtocolException
+//    {
+//        return delegate.execute( target, request, responseHandler, context );
+//    }
 
     @Override
     public void close()
@@ -130,6 +136,7 @@ public class TrackedHttpClient
         {
             managerWrapper.release();
         }
+        delegate.close();
     }
 
     @Override

--- a/src/test/java/org/commonjava/util/jhttpc/it/AbstractIT.java
+++ b/src/test/java/org/commonjava/util/jhttpc/it/AbstractIT.java
@@ -1,55 +1,40 @@
-/**
- * Copyright (C) 2015 Red Hat, Inc. (jdcasey@commonjava.org)
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *         http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package org.commonjava.util.jhttpc.it;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpDelete;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPut;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.commonjava.util.jhttpc.HttpFactory;
-import org.commonjava.util.jhttpc.INTERNAL.util.SSLUtils;
 import org.commonjava.util.jhttpc.auth.MemoryPasswordManager;
 import org.commonjava.util.jhttpc.auth.PasswordManager;
-import org.commonjava.util.jhttpc.auth.PasswordType;
-import org.commonjava.util.jhttpc.model.SiteConfig;
 import org.commonjava.util.jhttpc.model.SiteConfigBuilder;
+import org.commonjava.util.jhttpc.model.SiteTrustType;
 import org.commonjava.util.jhttpc.util.UrlUtils;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Rule;
-import org.junit.Test;
 import org.junit.rules.TestName;
 
 import java.io.File;
 import java.io.FileOutputStream;
-import java.security.KeyStore;
 import java.util.Arrays;
-import java.util.Enumeration;
 import java.util.List;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.junit.Assert.assertThat;
 
+/**
+ * Created by jdcasey on 5/30/17.
+ */
 public abstract class AbstractIT
 {
+    protected static final String SSL_CONFIG_BASE = "/ssl-config";
 
     private static final String NON_SSL_HOST = "docker.containers.%s.ports.80/tcp.host";
 
@@ -65,127 +50,7 @@ public abstract class AbstractIT
 
     private static final String CONTENT_MGMT_PATH = "/cgi-bin/content.py/";
 
-    protected static final String SSL_CONFIG_BASE = "/ssl-config";
-
     protected static final String SITE_CERT_PATH = SSL_CONFIG_BASE + "/site.crt";
-
-    @Test
-    public void clientSSLGet()
-            throws Exception
-    {
-        String path = "/private/" + name.getMethodName() + "/path/to/test";
-        String content = "This is a test.";
-
-        putContent( path, content );
-
-        SiteConfig config = getSiteConfigBuilder().withKeyCertPem( getClientKeyCertPem() ).build();
-        passwordManager.bind( "test", config, PasswordType.KEY );
-
-        CloseableHttpClient client = null;
-        try
-        {
-            client = factory.createClient( config );
-            CloseableHttpResponse response = client.execute( new HttpGet( formatSSLUrl( path ) ) );
-            assertThat( response.getStatusLine().getStatusCode(), equalTo( 200 ) );
-            String result = IOUtils.toString( response.getEntity().getContent() );
-
-            assertThat( result, equalTo( content ) );
-        }
-        finally
-        {
-            IOUtils.closeQuietly( client );
-        }
-    }
-
-    @Test
-    public void simpleSSLGet()
-            throws Exception
-    {
-        String path = name.getMethodName() + "/path/to/test";
-        String content = "This is a test.";
-
-        putContent( path, content );
-
-        SiteConfig config = getSiteConfigBuilder().build();
-        CloseableHttpClient client = null;
-        try
-        {
-            client = factory.createClient( config );
-            CloseableHttpResponse response = client.execute( new HttpGet( formatSSLUrl( path ) ) );
-            assertThat( response.getStatusLine().getStatusCode(), equalTo( 200 ) );
-            String result = IOUtils.toString( response.getEntity().getContent() );
-
-            assertThat( result, equalTo( content ) );
-        }
-        finally
-        {
-            IOUtils.closeQuietly( client );
-        }
-    }
-
-    @Test
-    public void simpleSingleGet_NoSSL()
-            throws Exception
-    {
-        String path = name.getMethodName() + "/path/to/test";
-        String content = "This is a test.";
-
-        putContent( path, content );
-
-        CloseableHttpClient client = null;
-        try
-        {
-            client = factory.createClient();
-            CloseableHttpResponse response = client.execute( new HttpGet( formatUrl( path ) ) );
-            assertThat( response.getStatusLine().getStatusCode(), equalTo( 200 ) );
-            String result = IOUtils.toString( response.getEntity().getContent() );
-
-            assertThat( result, equalTo( content ) );
-        }
-        finally
-        {
-            IOUtils.closeQuietly( client );
-        }
-    }
-
-    @Test
-    public void retrieveSiteCertificatePems()
-            throws Exception
-    {
-        String[] paths = getCertificatePaths();
-
-        CloseableHttpClient client = null;
-        try
-        {
-            client = factory.createClient();
-            for ( String path : paths )
-            {
-                CloseableHttpResponse response = client.execute( new HttpGet( formatUrl( path ) ) );
-                assertThat( response.getStatusLine().getStatusCode(), equalTo( 200 ) );
-                String result = IOUtils.toString( response.getEntity().getContent() );
-
-                System.out.println( result );
-                assertThat( result, notNullValue() );
-            }
-        }
-        finally
-        {
-            IOUtils.closeQuietly( client );
-        }
-    }
-
-    @Test
-    public void decodeSiteCertificatePems()
-            throws Exception
-    {
-        String pem = getServerCertsPem();
-        KeyStore store = SSLUtils.decodePEMTrustStore( pem, "somehost" );
-        Enumeration<String> aliases = store.aliases();
-        while ( aliases.hasMoreElements() )
-        {
-            System.out.println( aliases.nextElement() );
-        }
-    }
 
     @Rule
     public TestName name = new TestName();
@@ -194,11 +59,31 @@ public abstract class AbstractIT
 
     protected PasswordManager passwordManager;
 
-    protected abstract String getContainerId();
+    protected String getContainerId()
+    {
+        return "selfsigned";
+    }
 
-    protected abstract String[] getCertificatePaths();
+    protected String[] getCertificatePaths()
+    {
+        return new String[] { SITE_CERT_PATH };
+    }
 
     protected SiteConfigBuilder getSiteConfigBuilder()
+            throws Exception
+    {
+        return getSelfSignedSiteConfigBuilder();
+    }
+
+    protected SiteConfigBuilder getSelfSignedSiteConfigBuilder()
+            throws Exception
+    {
+        return new SiteConfigBuilder( getContainerId(), getSSLBaseUrl() ).withServerCertPem( getServerCertsPem() )
+                                                                         .withTrustType(
+                                                                                 SiteTrustType.TRUST_SELF_SIGNED );
+    }
+
+    protected SiteConfigBuilder getNormalSiteConfigBuilder()
             throws Exception
     {
         return new SiteConfigBuilder( getContainerId(), getSSLBaseUrl() ).withServerCertPem( getServerCertsPem() );
@@ -375,37 +260,6 @@ public abstract class AbstractIT
         return String.format( SSL_URL_FORMAT, host, port );
     }
 
-    //    protected void deleteContent( String path )
-    //            throws Exception
-    //    {
-    //        String url = formatUrl( CONTENT_MGMT_PATH, path );
-    //        HttpDelete put = new HttpDelete( url );
-    //
-    //        CloseableHttpClient client = null;
-    //        try
-    //        {
-    //            client = factory.createClient();
-    //            CloseableHttpResponse response = client.execute( put );
-    //            int code = response.getStatusLine().getStatusCode();
-    //            if ( code != 404 && code != 204 )
-    //            {
-    //                String extra = "";
-    //                if ( response.getEntity() != null )
-    //                {
-    //                    String body = IOUtils.toString( response.getEntity().getContent() );
-    //                    extra = "\nBody:\n\n" + body;
-    //                }
-    //
-    //                Assert.fail( "Failed to delete content from: " + path + ".\nURL: " + url + "\nStatus: "
-    //                                     + response.getStatusLine() + extra );
-    //            }
-    //        }
-    //        finally
-    //        {
-    //            IOUtils.closeQuietly( client );
-    //        }
-    //    }
-
     protected void putContent( String path, String content )
             throws Exception
     {
@@ -438,5 +292,37 @@ public abstract class AbstractIT
             IOUtils.closeQuietly( client );
         }
     }
+
+    protected void deleteContent( String path )
+            throws Exception
+    {
+        String url = formatUrl( CONTENT_MGMT_PATH, path );
+        HttpDelete put = new HttpDelete( url );
+
+        CloseableHttpClient client = null;
+        try
+        {
+            client = factory.createClient();
+            CloseableHttpResponse response = client.execute( put );
+            int code = response.getStatusLine().getStatusCode();
+            if ( code != 404 && code != 204 )
+            {
+                String extra = "";
+                if ( response.getEntity() != null )
+                {
+                    String body = IOUtils.toString( response.getEntity().getContent() );
+                    extra = "\nBody:\n\n" + body;
+                }
+
+                Assert.fail( "Failed to delete content from: " + path + ".\nURL: " + url + "\nStatus: "
+                                     + response.getStatusLine() + extra );
+            }
+        }
+        finally
+        {
+            IOUtils.closeQuietly( client );
+        }
+    }
+
 
 }

--- a/src/test/java/org/commonjava/util/jhttpc/it/AbstractSSLTestsIT.java
+++ b/src/test/java/org/commonjava/util/jhttpc/it/AbstractSSLTestsIT.java
@@ -1,0 +1,156 @@
+/**
+ * Copyright (C) 2015 Red Hat, Inc. (jdcasey@commonjava.org)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.commonjava.util.jhttpc.it;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.commonjava.util.jhttpc.INTERNAL.util.SSLUtils;
+import org.commonjava.util.jhttpc.auth.PasswordType;
+import org.commonjava.util.jhttpc.model.SiteConfig;
+import org.junit.Test;
+
+import java.security.KeyStore;
+import java.util.Enumeration;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.junit.Assert.assertThat;
+
+public abstract class AbstractSSLTestsIT
+        extends AbstractIT
+{
+
+    @Test
+    public void clientSSLGet()
+            throws Exception
+    {
+        String path = "/private/" + name.getMethodName() + "/path/to/test";
+        String content = "This is a test.";
+
+        putContent( path, content );
+
+        SiteConfig config = getSiteConfigBuilder().withKeyCertPem( getClientKeyCertPem() ).build();
+        passwordManager.bind( "test", config, PasswordType.KEY );
+
+        CloseableHttpClient client = null;
+        try
+        {
+            client = factory.createClient( config );
+            CloseableHttpResponse response = client.execute( new HttpGet( formatSSLUrl( path ) ) );
+            assertThat( response.getStatusLine().getStatusCode(), equalTo( 200 ) );
+            String result = IOUtils.toString( response.getEntity().getContent() );
+
+            assertThat( result, equalTo( content ) );
+        }
+        finally
+        {
+            IOUtils.closeQuietly( client );
+        }
+    }
+
+    @Test
+    public void simpleSSLGet()
+            throws Exception
+    {
+        String path = name.getMethodName() + "/path/to/test";
+        String content = "This is a test.";
+
+        putContent( path, content );
+
+        SiteConfig config = getSiteConfigBuilder().build();
+        CloseableHttpClient client = null;
+        try
+        {
+            client = factory.createClient( config );
+            CloseableHttpResponse response = client.execute( new HttpGet( formatSSLUrl( path ) ) );
+            assertThat( response.getStatusLine().getStatusCode(), equalTo( 200 ) );
+            String result = IOUtils.toString( response.getEntity().getContent() );
+
+            assertThat( result, equalTo( content ) );
+        }
+        finally
+        {
+            IOUtils.closeQuietly( client );
+        }
+    }
+
+    @Test
+    public void simpleSingleGet_NoSSL()
+            throws Exception
+    {
+        String path = name.getMethodName() + "/path/to/test";
+        String content = "This is a test.";
+
+        putContent( path, content );
+
+        CloseableHttpClient client = null;
+        try
+        {
+            client = factory.createClient();
+            CloseableHttpResponse response = client.execute( new HttpGet( formatUrl( path ) ) );
+            assertThat( response.getStatusLine().getStatusCode(), equalTo( 200 ) );
+            String result = IOUtils.toString( response.getEntity().getContent() );
+
+            assertThat( result, equalTo( content ) );
+        }
+        finally
+        {
+            IOUtils.closeQuietly( client );
+        }
+    }
+
+    @Test
+    public void retrieveSiteCertificatePems()
+            throws Exception
+    {
+        String[] paths = getCertificatePaths();
+
+        CloseableHttpClient client = null;
+        try
+        {
+            client = factory.createClient();
+            for ( String path : paths )
+            {
+                CloseableHttpResponse response = client.execute( new HttpGet( formatUrl( path ) ) );
+                assertThat( response.getStatusLine().getStatusCode(), equalTo( 200 ) );
+                String result = IOUtils.toString( response.getEntity().getContent() );
+
+                System.out.println( result );
+                assertThat( result, notNullValue() );
+            }
+        }
+        finally
+        {
+            IOUtils.closeQuietly( client );
+        }
+    }
+
+    @Test
+    public void decodeSiteCertificatePems()
+            throws Exception
+    {
+        String pem = getServerCertsPem();
+        KeyStore store = SSLUtils.decodePEMTrustStore( pem, "somehost" );
+        Enumeration<String> aliases = store.aliases();
+        while ( aliases.hasMoreElements() )
+        {
+            System.out.println( aliases.nextElement() );
+        }
+    }
+
+}

--- a/src/test/java/org/commonjava/util/jhttpc/it/inter/IntermediateSignedIT.java
+++ b/src/test/java/org/commonjava/util/jhttpc/it/inter/IntermediateSignedIT.java
@@ -15,13 +15,14 @@
  */
 package org.commonjava.util.jhttpc.it.inter;
 
-import org.commonjava.util.jhttpc.it.AbstractIT;
+import org.commonjava.util.jhttpc.it.AbstractSSLTestsIT;
+import org.commonjava.util.jhttpc.model.SiteConfigBuilder;
 
 /**
  * Created by jdcasey on 10/30/15.
  */
 public class IntermediateSignedIT
-        extends AbstractIT
+        extends AbstractSSLTestsIT
 {
     @Override
     protected String getContainerId()
@@ -30,10 +31,9 @@ public class IntermediateSignedIT
     }
 
     @Override
-    protected String[] getCertificatePaths()
+    protected SiteConfigBuilder getSiteConfigBuilder()
+            throws Exception
     {
-        return new String[]{SITE_CERT_PATH};
-//        return new String[]{SSL_CONFIG_BASE + "/root.crt", SSL_CONFIG_BASE + "/web.crt", SITE_CERT_PATH};
+        return getNormalSiteConfigBuilder();
     }
-
 }

--- a/src/test/java/org/commonjava/util/jhttpc/it/root/RootSignedIT.java
+++ b/src/test/java/org/commonjava/util/jhttpc/it/root/RootSignedIT.java
@@ -15,13 +15,14 @@
  */
 package org.commonjava.util.jhttpc.it.root;
 
-import org.commonjava.util.jhttpc.it.AbstractIT;
+import org.commonjava.util.jhttpc.it.AbstractSSLTestsIT;
+import org.commonjava.util.jhttpc.model.SiteConfigBuilder;
 
 /**
  * Created by jdcasey on 10/30/15.
  */
 public class RootSignedIT
-        extends AbstractIT
+        extends AbstractSSLTestsIT
 {
     @Override
     protected String getContainerId()
@@ -30,10 +31,9 @@ public class RootSignedIT
     }
 
     @Override
-    protected String[] getCertificatePaths()
+    protected SiteConfigBuilder getSiteConfigBuilder()
+            throws Exception
     {
-        return new String[]{SITE_CERT_PATH};
-//        return new String[]{SSL_CONFIG_BASE + "/root.crt", SITE_CERT_PATH};
+        return getNormalSiteConfigBuilder();
     }
-
 }

--- a/src/test/java/org/commonjava/util/jhttpc/it/self/SelfSignedIT.java
+++ b/src/test/java/org/commonjava/util/jhttpc/it/self/SelfSignedIT.java
@@ -15,17 +15,15 @@
  */
 package org.commonjava.util.jhttpc.it.self;
 
-import org.commonjava.util.jhttpc.it.AbstractIT;
-import org.commonjava.util.jhttpc.model.SiteConfig;
+import org.commonjava.util.jhttpc.it.AbstractSSLTestsIT;
 import org.commonjava.util.jhttpc.model.SiteConfigBuilder;
 import org.commonjava.util.jhttpc.model.SiteTrustType;
-import org.junit.Ignore;
 
 /**
  * Created by jdcasey on 10/30/15.
  */
 public class SelfSignedIT
-        extends AbstractIT
+        extends AbstractSSLTestsIT
 {
 //    @Override
 //    @Ignore( "Not supported in self-signed scenarios")
@@ -33,26 +31,5 @@ public class SelfSignedIT
 //            throws Exception
 //    {
 //    }
-
-    @Override
-    protected String getContainerId()
-    {
-        return "selfsigned";
-    }
-
-    @Override
-    protected String[] getCertificatePaths()
-    {
-        return new String[] { SITE_CERT_PATH };
-    }
-
-    @Override
-    protected SiteConfigBuilder getSiteConfigBuilder()
-            throws Exception
-    {
-        return new SiteConfigBuilder( getContainerId(), getSSLBaseUrl() ).withServerCertPem( getServerCertsPem() )
-                                                                         .withTrustType(
-                                                                                 SiteTrustType.TRUST_SELF_SIGNED );
-    }
 
 }

--- a/src/test/java/org/commonjava/util/jhttpc/unit/ResourceCleanupLoadTest.java
+++ b/src/test/java/org/commonjava/util/jhttpc/unit/ResourceCleanupLoadTest.java
@@ -1,0 +1,191 @@
+package org.commonjava.util.jhttpc.unit;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.conn.ConnectionPoolTimeoutException;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.commonjava.test.http.expect.ExpectationHandler;
+import org.commonjava.test.http.expect.ExpectationServer;
+import org.commonjava.util.jhttpc.HttpFactory;
+import org.commonjava.util.jhttpc.auth.MemoryPasswordManager;
+import org.commonjava.util.jhttpc.model.SiteConfig;
+import org.commonjava.util.jhttpc.model.SiteConfigBuilder;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestName;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.junit.Assert.assertThat;
+
+/**
+ * Created by jdcasey on 5/30/17.
+ */
+public class ResourceCleanupLoadTest
+{
+
+    private static final int THREAD_COUNT = 20;
+
+    @Rule
+    public ExpectationServer server = new ExpectationServer();
+
+    @Rule
+    public TestName name = new TestName();
+
+    private ExecutorService executor;
+
+    private HttpFactory factory;
+
+    @Before
+    public void setup()
+            throws Exception
+    {
+        executor = Executors.newFixedThreadPool( THREAD_COUNT );
+        factory = new HttpFactory( new MemoryPasswordManager() );
+    }
+
+    @Test
+    public void get20Times_RangedResponses()
+            throws Exception
+    {
+        final String path = name.getMethodName() + "/path/to/test";
+        final String content = "This is a test.";
+        final SiteConfig config = new SiteConfigBuilder( "test", server.formatUrl() ).withMaxConnections( 1 ).build();
+
+        final AtomicInteger ai = new AtomicInteger( 0 );
+        server.expect( "GET", server.formatUrl( path ), new ExpectationHandler()
+        {
+            @Override
+            public void handle( final HttpServletRequest httpServletRequest,
+                                final HttpServletResponse httpServletResponse )
+                    throws ServletException, IOException
+            {
+                int id = ai.incrementAndGet();
+                int code = ((id % 4) * 100 + 100 + (id % 5));
+                httpServletResponse.setStatus( code );
+                httpServletResponse.flushBuffer();
+            }
+        } );
+
+        final CountDownLatch latch = new CountDownLatch( THREAD_COUNT );
+
+        final AtomicBoolean timedOut = new AtomicBoolean( false );
+        for( int i=0; i<THREAD_COUNT; i++)
+        {
+            final int idx = i;
+            executor.execute( new Runnable(){
+                public void run(){
+                    String name = Thread.currentThread().getName();
+                    Thread.currentThread().setName( "GET#" + idx );
+                    CloseableHttpClient client = null;
+                    try
+                    {
+                        Logger logger = LoggerFactory.getLogger( getClass() );
+                        logger.info( "GET: {}", path );
+                        client = factory.createClient( config );
+                        logger.info( "Got client: {}", client );
+                        CloseableHttpResponse response = client.execute( new HttpGet( server.formatUrl( path ) ) );
+
+                        logger.info( "Response: {}", response.getStatusLine() );
+
+//                        assertThat( response.getStatusLine().getStatusCode(), equalTo( 200 ) );
+//                        String result = IOUtils.toString( response.getEntity().getContent() );
+
+//                        assertThat( result, equalTo( content ) );
+                    }
+                    catch ( ConnectionPoolTimeoutException e )
+                    {
+                        e.printStackTrace();
+                        timedOut.set( true );
+                    }
+                    catch ( Exception e )
+                    {
+                        e.printStackTrace();
+                    }
+                    finally
+                    {
+                        IOUtils.closeQuietly( client );
+                        Thread.currentThread().setName( name );
+                        latch.countDown();
+                    }
+                }
+            } );
+        }
+
+        latch.await();
+        assertThat( "Connection pool timed out!", timedOut.get(), equalTo( false ) );
+    }
+
+    @Test
+    public void getReadAndClose20Times()
+            throws Exception
+    {
+        final String path = name.getMethodName() + "/path/to/test";
+        final String content = "This is a test.";
+        final SiteConfig config = new SiteConfigBuilder( "test", server.formatUrl() ).withMaxConnections( 1 ).build();
+
+        server.expect( "GET", server.formatUrl( path ), 200, content );
+
+        final CountDownLatch latch = new CountDownLatch( THREAD_COUNT );
+
+        final AtomicBoolean timedOut = new AtomicBoolean( false );
+        for( int i=0; i<THREAD_COUNT; i++)
+        {
+            final int idx = i;
+            executor.execute( new Runnable(){
+                public void run(){
+                    String name = Thread.currentThread().getName();
+                    Thread.currentThread().setName( "GET#" + idx );
+                    CloseableHttpClient client = null;
+                    try
+                    {
+                        Logger logger = LoggerFactory.getLogger( getClass() );
+                        logger.info( "GET: {}", path );
+                        client = factory.createClient( config );
+                        logger.info( "Got client: {}", client );
+                        CloseableHttpResponse response = client.execute( new HttpGet( server.formatUrl( path ) ) );
+
+                        logger.info( "Response: {}", response.getStatusLine() );
+
+                        assertThat( response.getStatusLine().getStatusCode(), equalTo( 200 ) );
+                        String result = IOUtils.toString( response.getEntity().getContent() );
+
+                        assertThat( result, equalTo( content ) );
+                    }
+                    catch ( ConnectionPoolTimeoutException e )
+                    {
+                        e.printStackTrace();
+                        timedOut.set( true );
+                    }
+                    catch ( Exception e )
+                    {
+                        e.printStackTrace();
+                    }
+                    finally
+                    {
+                        IOUtils.closeQuietly( client );
+                        Thread.currentThread().setName( name );
+                        latch.countDown();
+                    }
+                }
+            } );
+        }
+
+        latch.await();
+        assertThat( "Connection pool timed out!", timedOut.get(), equalTo( false ) );
+    }
+
+}

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -1,0 +1,25 @@
+<!--
+  Copyright (c) 2014 Red Hat, Inc..
+  All rights reserved. This program and the accompanying materials
+  are made available under the terms of the GNU Public License v3.0
+  which accompanies this distribution, and is available at
+  http://www.gnu.org/licenses/gpl.html
+
+  Contributors:
+      Red Hat, Inc. - initial API and implementation
+-->
+<configuration>
+
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <!-- encoders are assigned the type
+         ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <root level="DEBUG">
+    <appender-ref ref="STDOUT" />
+  </root>
+
+</configuration>


### PR DESCRIPTION
Previously we had a TrackedHttpClient wrapper class that would keep track of
requests / responses used by the client. When you closed the client, it would
go through all associated resources that were still available (not GCed) and
close them too. However, TrackedHttpClient had some extra delegate methods that
caused it to circumvent the resource tracking in most cases. This has been fixed.

Also, in some cases where servers responded with nonsensical / invalid data, the
default response parser would hang. This would eventually cause connection pool
timeouts, since all connections would be stuck trying to parse garbage responses.
I've updated the response parser in use by our client to be less eager to make
order out of noise. This should allow garbage responses to throw an error, and
avoid locking up the system.