### PR TITLE
Make bouncycastle optional

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -126,10 +126,12 @@
     <dependency>
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcprov-jdk15on</artifactId>
+      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>org.bouncycastle</groupId>
       <artifactId>bcpkix-jdk15on</artifactId>
+      <optional>true</optional>
     </dependency>
     <dependency>
       <groupId>commons-io</groupId>

--- a/src/test/java/org/commonjava/util/jhttpc/unit/HttpFactoryTest.java
+++ b/src/test/java/org/commonjava/util/jhttpc/unit/HttpFactoryTest.java
@@ -25,7 +25,6 @@ import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.CloseableHttpClient;
-import org.bouncycastle.pkcs.PKCSException;
 import org.commonjava.test.http.expect.ExpectationServer;
 import org.commonjava.util.jhttpc.HttpFactory;
 import org.commonjava.util.jhttpc.INTERNAL.util.CertEnumerator;


### PR DESCRIPTION
The Bouncy Castle dependencies (`bcprov-jdk15on`, `bcpkix-jdk15on`) shouldn't be required by default since they are only used to read PEM SSL client keys.

According to `org.commonjava.util.jhttpc.INTERNAL.util.BouncyCastleUtils`, the Bouncy Castle dependencies should be closed off from the rest of the library:

```
 * Utilities that are firewalled to protect use cases that don't include BouncyCastle. NOTE: If you call this, you should
 * take some measure to ensure BC is available! (eg. Class.forname(..))
```

However, `SSLUtils.readKeyAndCert( kcPem, kcPass )` also uses bouncycastle  and returns a null result if bouncycastle is not on the classpath.