### PR TITLE
Separate connection pool timeout from request timeout and include sep…

### DIFF
--- a/src/main/java/org/commonjava/util/jhttpc/HttpFactory.java
+++ b/src/main/java/org/commonjava/util/jhttpc/HttpFactory.java
@@ -139,7 +139,7 @@ public class HttpFactory
 
             final int timeout = 1000 * location.getRequestTimeoutSeconds();
             builder.setDefaultRequestConfig( RequestConfig.custom()
-                                                          .setConnectionRequestTimeout( timeout )
+//                                                          .setConnectionRequestTimeout( timeout )
                                                           .setSocketTimeout( timeout )
                                                           .setConnectTimeout( timeout )
                                                           .build() );

--- a/src/main/java/org/commonjava/util/jhttpc/INTERNAL/conn/CloseBlockingConnectionManager.java
+++ b/src/main/java/org/commonjava/util/jhttpc/INTERNAL/conn/CloseBlockingConnectionManager.java
@@ -19,6 +19,7 @@ import org.apache.http.HttpClientConnection;
 import org.apache.http.conn.ConnectionRequest;
 import org.apache.http.conn.HttpClientConnectionManager;
 import org.apache.http.conn.routing.HttpRoute;
+import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
 import org.apache.http.protocol.HttpContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -35,9 +36,9 @@ public class CloseBlockingConnectionManager
 
     private final SiteConnectionConfig config;
 
-    private final HttpClientConnectionManager connectionManager;
+    private final PoolingHttpClientConnectionManager connectionManager;
 
-    public CloseBlockingConnectionManager( final SiteConnectionConfig config, final HttpClientConnectionManager connectionManager )
+    public CloseBlockingConnectionManager( final SiteConnectionConfig config, final PoolingHttpClientConnectionManager connectionManager )
     {
         this.config = config;
         this.connectionManager = connectionManager;
@@ -93,7 +94,8 @@ public class CloseBlockingConnectionManager
     @Override
     public void shutdown()
     {
-        logger.trace( "BLOCKED connection-manager shutdown. This is intentional, to make the connection pool reusable." );
+        logger.trace( "BLOCKED connection-manager shutdown; connection pool is reusable.\n\n{}\n\n",
+                      this );
     }
 
     public void reallyShutdown()
@@ -112,9 +114,10 @@ public class CloseBlockingConnectionManager
     public String toString()
     {
         return "CloseBlockingConnectionManager{" +
-                "config=" + config +
-                ", connectionManager=" + connectionManager +
-                ", instance=" + super.hashCode() +
-                '}';
+                "\nconfig=" + config +
+                "\nconnectionManager=" + connectionManager +
+                "\ninstance=" + super.hashCode() +
+                "\nstats=" + connectionManager == null ? "NONE" : connectionManager.getTotalStats() +
+                "\n}";
     }
 }

--- a/src/main/java/org/commonjava/util/jhttpc/model/SiteConfig.java
+++ b/src/main/java/org/commonjava/util/jhttpc/model/SiteConfig.java
@@ -33,6 +33,8 @@ public final class SiteConfig
 
     public static final int DEFAULT_MAX_CONNECTIONS = 4;
 
+    public static final int DEFAULT_CONNECTION_POOL_TIMEOUT_SECONDS = 60;
+
     private final String id;
 
     private final String uri;
@@ -57,9 +59,11 @@ public final class SiteConfig
 
     private final Integer maxConnections;
 
+    private final Integer connectionPoolTimeoutSeconds;
+
     SiteConfig( String id, String uri, String user, String proxyHost, Integer proxyPort, String proxyUser,
                        SiteTrustType trustType, String keyCertPem, String serverCertPem, Integer requestTimeoutSeconds,
-                       Integer maxConnections, Map<String, Object> attributes )
+                       Integer connectionPoolTimeoutSeconds, Integer maxConnections, Map<String, Object> attributes )
     {
         this.id = id;
         this.uri = uri;
@@ -71,6 +75,7 @@ public final class SiteConfig
         this.keyCertPem = keyCertPem;
         this.serverCertPem = serverCertPem;
         this.requestTimeoutSeconds = requestTimeoutSeconds;
+        this.connectionPoolTimeoutSeconds = connectionPoolTimeoutSeconds;
         this.maxConnections = maxConnections;
         this.attributes = attributes == null ? new HashMap<String, Object>() : attributes;
     }
@@ -137,6 +142,11 @@ public final class SiteConfig
     public String getServerCertPem()
     {
         return serverCertPem;
+    }
+
+    public int getConnectionPoolTimeoutSeconds()
+    {
+        return connectionPoolTimeoutSeconds == null ? DEFAULT_CONNECTION_POOL_TIMEOUT_SECONDS : connectionPoolTimeoutSeconds;
     }
 
     public int getRequestTimeoutSeconds()

--- a/src/main/java/org/commonjava/util/jhttpc/model/SiteConfigBuilder.java
+++ b/src/main/java/org/commonjava/util/jhttpc/model/SiteConfigBuilder.java
@@ -20,18 +20,16 @@ import java.net.URL;
 import java.util.HashMap;
 import java.util.Map;
 
+import static org.commonjava.util.jhttpc.model.SiteConfig.DEFAULT_CONNECTION_POOL_TIMEOUT_SECONDS;
+import static org.commonjava.util.jhttpc.model.SiteConfig.DEFAULT_MAX_CONNECTIONS;
+import static org.commonjava.util.jhttpc.model.SiteConfig.DEFAULT_PROXY_PORT;
+import static org.commonjava.util.jhttpc.model.SiteConfig.DEFAULT_REQUEST_TIMEOUT_SECONDS;
+
 /**
  * Created by jdcasey on 10/28/15.
  */
 public class SiteConfigBuilder
 {
-
-    // TODO: too low?
-    public static final int DEFAULT_REQUEST_TIMEOUT_SECONDS = 10;
-
-    public static final int DEFAULT_PROXY_PORT = 8080;
-
-    public static final int DEFAULT_MAX_CONNECTIONS = 4;
 
     private String id;
 
@@ -55,6 +53,8 @@ public class SiteConfigBuilder
 
     private Integer requestTimeoutSeconds;
 
+    private Integer connectionPoolTimeoutSeconds;
+
     private Integer maxConnections;
 
     public Map<String, Object> getAttributes()
@@ -75,7 +75,7 @@ public class SiteConfigBuilder
     public SiteConfig build()
     {
         return new SiteConfig( id, uri, user, proxyHost, proxyPort, proxyUser, trustType, keyCertPem, serverCertPem,
-                               requestTimeoutSeconds, maxConnections, attributes );
+                               requestTimeoutSeconds, connectionPoolTimeoutSeconds, maxConnections, attributes );
     }
 
     public String getId()
@@ -140,6 +140,13 @@ public class SiteConfigBuilder
     public int getRequestTimeoutSeconds()
     {
         return requestTimeoutSeconds == null ? DEFAULT_REQUEST_TIMEOUT_SECONDS : requestTimeoutSeconds;
+    }
+
+    public int getConnectionPoolTimeoutSeconds()
+    {
+        return connectionPoolTimeoutSeconds == null ?
+                DEFAULT_CONNECTION_POOL_TIMEOUT_SECONDS :
+                connectionPoolTimeoutSeconds;
     }
 
     public synchronized Object setAttribute( String key, Object value )
@@ -220,6 +227,12 @@ public class SiteConfigBuilder
     public SiteConfigBuilder withRequestTimeoutSeconds( Integer requestTimeoutSeconds )
     {
         this.requestTimeoutSeconds = requestTimeoutSeconds;
+        return this;
+    }
+
+    public SiteConfigBuilder withConnectionPoolTimeoutSeconds( Integer timeoutSeconds )
+    {
+        this.connectionPoolTimeoutSeconds = timeoutSeconds;
         return this;
     }
 


### PR DESCRIPTION
…arate config point for it

In cases where applications have large thread pools driving connections to Koji, but the
Koji connection pool is relatively small (to help avoid swamping Koji, for instance),
having the connection pool timeout set the same as the request timeout doesn't make sense.

In many cases, the requests in question may take a small fraction of the time it would
take to pare down the waiting-threads list, leading to either artificially high request
timeouts, or a lot of ConnectionTimeoutException errors.

This change fixes the problem by separating these configuration points, and setting
the default connection pool timeout to 60 seconds (the request timeout default is 30).