### PR TITLE
Use NoopHostnameVerifier when ignoreHostnameVerification is true

### DIFF
--- a/src/main/java/org/commonjava/util/jhttpc/HttpFactory.java
+++ b/src/main/java/org/commonjava/util/jhttpc/HttpFactory.java
@@ -400,8 +400,8 @@ public class HttpFactory
             logger.debug( "No server certificates found" );
         }
 
-        // if user set either ks, ts, or ignore hostname verification, we know this is a ssl factory and set it accordingly
-        if ( ks != null || ts != null || !location.isHostnameVerified() )
+        // if user set either ks, ts, or want to ignore hostname verification, we know this is a ssl factory and set it accordingly
+        if ( ks != null || ts != null || location.isIgnoreHostnameVerification() )
         {
             logger.debug( "Setting up SSL context." );
             try
@@ -429,13 +429,13 @@ public class HttpFactory
                 }
 
                 SSLContext ctx = sslBuilder.build();
-                if ( location.isHostnameVerified() )
+                if ( location.isIgnoreHostnameVerification() )
                 {
-                    fac = new SSLConnectionSocketFactory( ctx, new DefaultHostnameVerifier() );
+                    fac = new SSLConnectionSocketFactory( ctx, new NoopHostnameVerifier() );
                 }
                 else
                 {
-                    fac = new SSLConnectionSocketFactory( ctx, new NoopHostnameVerifier() );
+                    fac = new SSLConnectionSocketFactory( ctx, new DefaultHostnameVerifier() );
                 }
 
                 location.setAttribute( SSL_FACTORY_ATTRIB, fac );

--- a/src/main/java/org/commonjava/util/jhttpc/model/SiteConfig.java
+++ b/src/main/java/org/commonjava/util/jhttpc/model/SiteConfig.java
@@ -76,13 +76,13 @@ public final class SiteConfig
 
     private HttpClientContext clientContextPrototype;
 
-    private final boolean hostnameVerified;
+    private final boolean ignoreHostnameVerification;
 
     SiteConfig( String id, String uri, String user, String proxyHost, Integer proxyPort, String proxyUser,
                 SiteTrustType trustType, String keyCertPem, String serverCertPem, Integer requestTimeoutSeconds,
                 Integer connectionPoolTimeoutSeconds, Integer maxConnections, Integer maxPerRoute,
                 final ConnectionConfig connectionConfig, final SocketConfig socketConfig,
-                final RequestConfig requestConfig, HttpClientContext clientContextPrototype, boolean hostnameVerified, Map<String, Object> attributes )
+                final RequestConfig requestConfig, HttpClientContext clientContextPrototype, boolean ignoreHostnameVerification, Map<String, Object> attributes )
     {
         this.id = id;
         this.uri = uri;
@@ -101,7 +101,7 @@ public final class SiteConfig
         this.socketConfig = socketConfig;
         this.requestConfig = requestConfig;
         this.clientContextPrototype = clientContextPrototype;
-        this.hostnameVerified = hostnameVerified;
+        this.ignoreHostnameVerification = ignoreHostnameVerification;
         this.attributes = attributes == null ? new HashMap<String, Object>() : attributes;
     }
 
@@ -283,9 +283,9 @@ public final class SiteConfig
         return clientContextPrototype;
     }
 
-    public boolean isHostnameVerified()
+    public boolean isIgnoreHostnameVerification()
     {
-        return hostnameVerified;
+        return ignoreHostnameVerification;
     }
 
 }

--- a/src/main/java/org/commonjava/util/jhttpc/model/SiteConfigBuilder.java
+++ b/src/main/java/org/commonjava/util/jhttpc/model/SiteConfigBuilder.java
@@ -72,7 +72,7 @@ public class SiteConfigBuilder
 
     private HttpClientContext clientContextProtoype;
 
-    private boolean hostnameVerified;
+    private boolean ignoreHostnameVerification;
 
     public Map<String, Object> getAttributes()
     {
@@ -93,7 +93,8 @@ public class SiteConfigBuilder
     {
         return new SiteConfig( id, uri, user, proxyHost, proxyPort, proxyUser, trustType, keyCertPem, serverCertPem,
                                requestTimeoutSeconds, connectionPoolTimeoutSeconds, maxConnections, maxPerRoute,
-                               connectionConfig, socketConfig, requestConfig, clientContextProtoype, hostnameVerified, attributes );
+                               connectionConfig, socketConfig, requestConfig, clientContextProtoype,
+                               ignoreHostnameVerification, attributes );
     }
 
     public String getId()
@@ -287,9 +288,9 @@ public class SiteConfigBuilder
         return this;
     }
 
-    public SiteConfigBuilder withHostnameVerified( final boolean hostnameVerified )
+    public SiteConfigBuilder withIgnoreHostnameVerification( final boolean ignoreHostnameVerification )
     {
-        this.hostnameVerified = hostnameVerified;
+        this.ignoreHostnameVerification = ignoreHostnameVerification;
         return this;
     }
 


### PR DESCRIPTION
I might misunderstand "hostnameVerified" in prev PR. Here is how I think. 
1. The default hostnameVerified is false. jhttpc will do normal hostname verification. 
2. If the user sets it to true, it means the remote hostname is guaranteed right and jhttpc don't need to verify it. So jhttpc use no-op verifier in this case. 
If my understanding is right, here is the change to the code. 
PS. Maybe we can use the name "ignoreHostnameVerification"? This is a more straightforward name to ask jhttpc not to do something. WDT?