### PR TITLE
Fix: upgrade web-commons due to logback CVE fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
   <parent>
     <groupId>org.commonjava</groupId>
     <artifactId>commonjava</artifactId>
-    <version>14</version>
+    <version>17</version>
   </parent>
 
   <groupId>org.commonjava.util</groupId>
@@ -42,8 +42,10 @@
     <pmd.skip>true</pmd.skip>
     <projectOwner>Red Hat, Inc.</projectOwner>
     <javaVersion>1.8</javaVersion>
-    <httpcoreVersion>4.4.6</httpcoreVersion>
-    <httpclientVersion>4.5.3</httpclientVersion>
+    <httpcoreVersion>4.4.15</httpcoreVersion>
+    <httpclientVersion>4.5.13</httpclientVersion>
+
+    <bouncycastleVersion>1.71.1</bouncycastleVersion>
     <dockerWaitFor>Setting LogLevel for all modules to trace6</dockerWaitFor>
 
     <dockerImage>docker.io/commonjava/ssl-dojo:1.1</dockerImage>
@@ -75,7 +77,7 @@
       <dependency>
         <groupId>org.commonjava.boms</groupId>
         <artifactId>web-commons-bom</artifactId>
-        <version>27-SNAPSHOT</version>
+        <version>27</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -92,23 +94,23 @@
       </dependency>
       <dependency>
         <groupId>org.bouncycastle</groupId>
-        <artifactId>bcprov-jdk15on</artifactId>
-        <version>1.53</version>
+        <artifactId>bcprov-jdk18on</artifactId>
+        <version>${bouncycastleVersion}</version>
       </dependency>
       <dependency>
         <groupId>org.bouncycastle</groupId>
-        <artifactId>bcpkix-jdk15on</artifactId>
-        <version>1.53</version>
+        <artifactId>bcpkix-jdk18on</artifactId>
+        <version>${bouncycastleVersion}</version>
       </dependency>
       <dependency>
         <groupId>commons-codec</groupId>
         <artifactId>commons-codec</artifactId>
-        <version>1.6</version>
+        <version>1.15</version>
       </dependency>
       <dependency>
         <groupId>org.commonjava.util</groupId>
         <artifactId>http-testserver</artifactId>
-        <version>1.3</version>
+        <version>1.4</version>
         <scope>test</scope>
       </dependency>
     </dependencies>
@@ -125,11 +127,11 @@
     </dependency>
     <dependency>
       <groupId>org.bouncycastle</groupId>
-      <artifactId>bcprov-jdk15on</artifactId>
+      <artifactId>bcprov-jdk18on</artifactId>
     </dependency>
     <dependency>
       <groupId>org.bouncycastle</groupId>
-      <artifactId>bcpkix-jdk15on</artifactId>
+      <artifactId>bcpkix-jdk18on</artifactId>
     </dependency>
     <dependency>
       <groupId>commons-io</groupId>
@@ -189,7 +191,7 @@
       <plugins>
         <plugin>
           <artifactId>maven-dependency-plugin</artifactId>
-          <version>2.8</version>
+          <version>3.3.0</version>
           <executions>
             <execution>
               <id>default-cli</id>

--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
       <dependency>
         <groupId>org.commonjava.boms</groupId>
         <artifactId>web-commons-bom</artifactId>
-        <version>21</version>
+        <version>27-SNAPSHOT</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
https://cve.report/CVE-2021-42550

And other deps upgrade:

  * commonjava-parent: 14 -> 17
  * httpcore: 4.4.6 -> 4.4.15
  * httpclient: 4.5.3 -> 4.5.13
  * web-commons-bom: 27-SNAPSHOT -> 27
  * bcprov-jdk15on -> bcprov-jdk18on
  * bcpkix-jdk15on -> bcpkix-jdk18on
  * http-testserver: 1.3 -> 1.4
  * maven-dependency-plugin: 2.8 -> 3.3.0